### PR TITLE
Stay on CentOS 7.3 as 7.4 deprecates OpenStack Mitaka

### DIFF
--- a/openio-sds/16.10/Dockerfile
+++ b/openio-sds/16.10/Dockerfile
@@ -1,12 +1,18 @@
-FROM centos:7
+FROM centos:7.3.1611
 MAINTAINER "Romain Acciari" <romain.acciari@openio.io>
 
 ENV OIOSDS_RELEASE 16.10
 ENV REPO_OPENIO http://mirror.openio.io/pub/repo/openio/sds/${OIOSDS_RELEASE}/el/openio-sds-release-${OIOSDS_RELEASE}-1.el.noarch.rpm
 ENV PUPPET_PROFILE docker
 
-# Install and configure OpenIO
-RUN yum clean all \
+# Force the mirror definitions to point to the 7.3.1611 subdirectory, as for
+# CentOS-Base the default is still to use $releasever (which is just "7")
+# and for OpenStack, the default is hardcoded to just "7".
+# Then install and configure OpenIO
+RUN sed -i -e 's/\$releasever/7.3.1611/g' -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=/baseurl=/g' /etc/yum.repos.d/CentOS-Base.repo \
+  && yum clean all \
+  && yum -y install centos-release-openstack-mitaka \
+  && sed -i -e 's|centos/7/cloud|centos/7.3.1611/cloud|g' /etc/yum.repos.d/CentOS-OpenStack-mitaka.repo \
   && yum -y --disableplugin=fastestmirror install ${REPO_OPENIO} \
   && yum -y --disableplugin=fastestmirror update \
   && yum -y --disableplugin=fastestmirror install puppet-openio-sds-profile ${ADDITIONAL_PKGS} \


### PR DESCRIPTION
- Force the docker image source
- Force the CentOS-Base repo URL
- Force the OpenStack repo url
- Keep the "yum clean all" where it is required