### PR TITLE
Pass PUPPETOPTS="--color=none" to make output saner for text log files

### DIFF
--- a/openio-sds/16.10/centos/7/Dockerfile
+++ b/openio-sds/16.10/centos/7/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER "Romain Acciari" <romain.acciari@openio.io>
 ENV OIOSDS_RELEASE 16.10
 ENV REPO_OPENIO http://mirror.openio.io/pub/repo/openio/sds/${OIOSDS_RELEASE}/el/openio-sds-release-${OIOSDS_RELEASE}-1.el.noarch.rpm
 ENV PUPPET_PROFILE docker
+ENV PUPPETOPTS --color=none
 
 # Force the mirror definitions to point to the 7.3.1611 subdirectory, as for
 # CentOS-Base the default is still to use $releasever (which is just "7")

--- a/openio-sds/17.04/centos/7/Dockerfile
+++ b/openio-sds/17.04/centos/7/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER "Romain Acciari" <romain.acciari@openio.io>
 ENV OIOSDS_RELEASE 17.04
 ENV REPO_OPENIO http://mirror.openio.io/pub/repo/openio/sds/${OIOSDS_RELEASE}/el/openio-sds-release-${OIOSDS_RELEASE}-1.el.noarch.rpm
 ENV PUPPET_PROFILE docker
+ENV PUPPETOPTS --color=none
 
 # Install and configure OpenIO
 RUN yum clean all \

--- a/openio-sds/17.04/ubuntu/xenial/Dockerfile
+++ b/openio-sds/17.04/ubuntu/xenial/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER "Romain Acciari" <romain.acciari@openio.io>
 ENV OIOSDS_RELEASE 17.04
 ENV REPO_OPENIO http://mirror.openio.io/pub/repo/openio/sds/${OIOSDS_RELEASE}/ubuntu
 ENV PUPPET_PROFILE docker
+ENV PUPPETOPTS --color=none
 
 RUN apt-get update
 RUN apt-get install -y curl wget


### PR DESCRIPTION
See [open-io/puppet-openiosds-profile PR 8](https://github.com/open-io/puppet-openiosds-profile/pull/8), for the required change needed before this one