### PR TITLE
Change shebang to bash for Ubuntu Xenial builds

### DIFF
--- a/openio-sds/17.04/ubuntu/xenial/Dockerfile
+++ b/openio-sds/17.04/ubuntu/xenial/Dockerfile
@@ -44,4 +44,4 @@ VOLUME ["/var/lib/oio/sds/OPENIO"]
 ADD openio-docker-init.sh /
 EXPOSE 6007
 ADD swift.pp /root/swift.pp
-CMD ["/bin/bash", "/openio-docker-init.sh"]
+CMD ["/openio-docker-init.sh"]

--- a/openio-sds/17.04/ubuntu/xenial/openio-docker-init.sh
+++ b/openio-sds/17.04/ubuntu/xenial/openio-docker-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Default configuration
 NS='OPENIO'


### PR DESCRIPTION
Unlike Centos, on Ubuntu `/bin/sh` is not a an alias to `/bin/bash` this has the consequence to make the script `openio-docker-init.sh` uncallable.