### PR TITLE
Misc CEPH S3 testing image work

### DIFF
--- a/ceph-s3-tests/Dockerfile
+++ b/ceph-s3-tests/Dockerfile
@@ -5,13 +5,13 @@ ARG AWS_S3_PORT
 
 RUN rm -rf /var/cache/yum
 RUN yum -y clean all
-RUN yum -y install deltarpm
+RUN yum -y install deltarpm epel-release
 
 RUN yum -y update
 
-RUN yum -y install epel-release
-RUN yum -y install git python-pip python-virtualenv
-RUN yum -y install libevent-devel libxml2-devel libxslt-devel zlib-devel
+RUN yum -y install \
+    git python-pip python-virtualenv sudo libffi-devel \
+    libevent-devel libxml2-devel libxslt-devel zlib-devel
 
 RUN git clone https://github.com/ceph/s3-tests.git
 

--- a/ceph-s3-tests/s3-ceph.cfg
+++ b/ceph-s3-tests/s3-ceph.cfg
@@ -39,3 +39,11 @@ display_name = test2
 email = test2@localhost
 access_key = test2:tester2
 secret_key = testing2
+
+[s3 tenant]
+user_id = admin
+display_name = admin
+email = admin@localhost
+access_key = admin:admin
+secret_key = admin
+


### PR DESCRIPTION
    - Install EPEL before system update
    - Merge yum package installations
    - Add missing `sudo` required by bootstrap script
    - Preinstall `libffi-devel` to avoid doing it at `docker run` time
    - Add `s3 tenant` config section to enable more tests to be run