### PR TITLE
FEATURE(SDS): manage ACL in image 18.10

### DIFF
--- a/openio-sds/18.10/centos/7/standalone.yml
+++ b/openio-sds/18.10/centos/7/standalone.yml
@@ -36,4 +36,17 @@ openio_rdir_serviceid: 1
 openio_manage_os_requirement: false
 
 openio_account_redis_standalone: "127.0.0.1:6011"
+
+openio_oioswift_filter_swift3:
+  use: "egg:swift3#swift3"
+  force_swift_request_proxy_log: true
+  s3_acl: true
+  check_bucket_owner: true
+  location: "us-east-1"
+  # always set same value
+  max_bucket_listing: 1000
+  max_multi_delete_objects: 1000
+  bucket_db_enabled: true
+  bucket_db_host: "127.0.0.1:6011"
+
 ...


### PR DESCRIPTION
 ##### SUMMARY

Add the bucketdb in swift3

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

Validation
```console
$ cat .aws/credentials
[default]
aws_access_key_id = demo:demo
aws_secret_access_key = DEMO_PASS
```
`docker run -e SWIFT_CREDENTIALS="demo:demo:DEMO_PASS:.admin,test:test:TEST_PASS:.admin" openio/sds:18.10`
```shell
aws s3 mb s3://test1 --endpoint-url http://172.17.0.2:6007 --no-verify-ssl
aws s3api put-object --bucket test1 --acl public-read --key issue --body /etc/issue --endpoint-url http://172.17.0.2:6007 --no-verify-ssl
aws s3api put-bucket-acl --bucket test1 --grant-read id="test:test" --endpoint-url http://172.17.0.2:6007 --no-verify-ssl
aws s3api put-object-acl --bucket test1 --key issue --grant-read id="test:test" --endpoint-url http://172.17.0.2:6007 --no-verify-ssl
aws s3api get-bucket-acl --bucket test1  --endpoint-url http://172.17.0.2:6007 --no-verify-ssl
aws s3api get-object-acl --bucket test1 --key issue --endpoint-url http://172.17.0.2:6007 --no-verify-ssl
```

```console
$ cat .aws/credentials
[default]
aws_access_key_id = test:test
aws_secret_access_key = TEST_PASS
```
```shell
aws s3 ls s3://test1 --endpoint-url http://172.17.0.2:6007
aws s3 cp   --endpoint-url http://172.17.0.2:6007 s3://test1/issue /tmp/plop
```