### PR TITLE
BUGFIX/MEDIUM(SDS): Wrong pipeline when keystone is used

### DIFF
--- a/openio-sds/20.04/openio-docker-init.sh
+++ b/openio-sds/20.04/openio-docker-init.sh
@@ -200,7 +200,7 @@ function keystone_config(){
     : "${SWIFT_PASSWORD:=SWIFT_PASS}"
     sed -i -e "/filter:tempauth/i [filter:s3token]\ndelay_auth_decision = True\nauth_uri = http://${KEYSTONE_URL}/\nuse = egg:swift3#s3token\n\n[filter:authtoken]\nauth_type = password\nusername = ${SWIFT_USERNAME}\nproject_name = service\nregion_name = ${REGION}\nuser_domain_id = default\nmemcache_secret_key = memcache_secret_key\npaste.filter_factory = keystonemiddleware.auth_token:filter_factory\ninsecure = True\ncache = swift.cache\ndelay_auth_decision = True\ntoken_cache_time = 300\nauth_url =http://${KEYSTONE_URL}\ninclude_service_catalog = False\nwww_authenticate_uri = http://${KEYSTONE_URI}\nmemcached_servers = ${IPADDR}:6019\npassword = ${SWIFT_PASSWORD}\nrevocation_cache_time = 60\nmemcache_security_strategy = ENCRYPT\nproject_domain_id = default\n\n[filter:keystoneauth]\nuse = egg:swift#keystoneauth\noperator_roles = admin,swiftoperator,_member_\n" /etc/oio/sds/OPENIO/oioswift-0/proxy-server.conf
     sed -i -e '/filter:tempauth/,+2d' /etc/oio/sds/OPENIO/oioswift-0/proxy-server.conf
-    sed -i -e 's@^pipeline =.*@pipeline = catch_errors gatekeeper healthcheck proxy-logging cache bulk tempurl proxy-logging authtoken swift3 s3token keystoneauth proxy-logging copy container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server@' /etc/oio/sds/OPENIO/oioswift-0/proxy-server.conf
+    sed -i -e 's@^pipeline =.*@pipeline = catch_errors gatekeeper healthcheck proxy-logging cache bulk tempurl proxy-logging authtoken swift3 s3token keystoneauth proxy-logging copy slo dlo versioned_writes proxy-logging proxy-server@' /etc/oio/sds/OPENIO/oioswift-0/proxy-server.conf
   fi
 }
 

--- a/openio-sds/20.04/openio-docker-init.sh
+++ b/openio-sds/20.04/openio-docker-init.sh
@@ -112,7 +112,7 @@ function initcluster(){
   # Temporarily disabling the swift gateway, to avoid answering when not completely setup
   sed -i -e 's/^enabled=.*$/enabled=false/' /etc/gridinit.d/OPENIO-oioswift-0.conf
 
-	rm /etc/oio/sds/OPENIO/conscience-0/conscience-0-persistence.dat
+  rm /etc/oio/sds/OPENIO/conscience-0/conscience-0-persistence.dat
   echo "> Starting services"
   /usr/bin/gridinit -d /etc/gridinit.conf >/dev/null 2>&1
 
@@ -237,6 +237,8 @@ if [ ! -f /etc/oio/sds/firstboot ]; then
     /usr/bin/find /etc/oio /etc/gridinit.d /root /usr/bin/openio-basic-checks -type f -print0 | xargs --no-run-if-empty -0 sed -i "s/127.0.0.1/${IPADDR}/g"
   fi
 
+  # Activate logs
+  /usr/sbin/rsyslogd
   # Deploy OpenIO
   initcluster
 
@@ -250,8 +252,6 @@ fi
 # Re-enabling the swift gateway, now that it's ready
 sed -i -e 's/^enabled=.*$/enabled=true/' /etc/gridinit.d/OPENIO-oioswift-0.conf
 
-# Activate logs
-/usr/sbin/rsyslogd
 
 echo "
      .oo.   .ooo.       OIO Conscience:   ${IPADDR}:6000


### PR DESCRIPTION
 ##### SUMMARY

Since 20.04, middlewares `container-quotas` and `account-quotas` doesn't exist in the configuration file

```console
pipeline = catch_errors gatekeeper healthcheck proxy-logging cache bulk tempurl proxy-logging swift3 tempauth proxy-logging copy slo dlo versioned_writes proxy-logging proxy-server
```
 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://github.com/open-io/dockerfiles/issues/123